### PR TITLE
Add option to manually hook the IDT.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ default: all
 
 # Actual sources
 SRCS += $(shell find ./src/ -name '*.c')
+SRCS += $(shell find ./src/ -name '*.nasm')
 
 # All the headers, we use them as dependency
 HDRS += $(shell find ./src/ -name '*.h')
@@ -117,6 +118,9 @@ clean:
 #########################
 
 all: ./bin/BOOTX64.EFI
+debug: ./bin/BOOTX64.EFI
+
+debug: CFLAGS += -D TBOOT_DEBUG
 
 # specifically for the uefi lib
 # we need to generate that file, have it depend on the includes of UEFI

--- a/src/debug/exception.c
+++ b/src/debug/exception.c
@@ -1,0 +1,263 @@
+#include <debug/exception.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+#define EXCEPT_IA32_DIVIDE_ERROR    0
+#define EXCEPT_IA32_DEBUG           1
+#define EXCEPT_IA32_NMI             2
+#define EXCEPT_IA32_BREAKPOINT      3
+#define EXCEPT_IA32_OVERFLOW        4
+#define EXCEPT_IA32_BOUND           5
+#define EXCEPT_IA32_INVALID_OPCODE  6
+#define EXCEPT_IA32_DOUBLE_FAULT    8
+#define EXCEPT_IA32_INVALID_TSS     10
+#define EXCEPT_IA32_SEG_NOT_PRESENT 11
+#define EXCEPT_IA32_STACK_FAULT     12
+#define EXCEPT_IA32_GP_FAULT        13
+#define EXCEPT_IA32_PAGE_FAULT      14
+#define EXCEPT_IA32_FP_ERROR        16
+#define EXCEPT_IA32_ALIGNMENT_CHECK 17
+#define EXCEPT_IA32_MACHINE_CHECK   18
+#define EXCEPT_IA32_SIMD            19
+
+static int EXCEPTIONS[] = {
+        EXCEPT_IA32_DIVIDE_ERROR,
+        EXCEPT_IA32_DEBUG,
+        EXCEPT_IA32_NMI,
+        EXCEPT_IA32_BREAKPOINT,
+        EXCEPT_IA32_OVERFLOW,
+        EXCEPT_IA32_BOUND,
+        EXCEPT_IA32_INVALID_OPCODE,
+        EXCEPT_IA32_DOUBLE_FAULT,
+        EXCEPT_IA32_INVALID_TSS,
+        EXCEPT_IA32_SEG_NOT_PRESENT,
+        EXCEPT_IA32_STACK_FAULT,
+        EXCEPT_IA32_GP_FAULT,
+        EXCEPT_IA32_PAGE_FAULT,
+        EXCEPT_IA32_FP_ERROR,
+        EXCEPT_IA32_ALIGNMENT_CHECK,
+        EXCEPT_IA32_MACHINE_CHECK,
+        EXCEPT_IA32_SIMD,
+};
+
+static const char* EXCEPTION_NAMES[] = {
+        [EXCEPT_IA32_DIVIDE_ERROR] = "Divide by zero",
+        [EXCEPT_IA32_DEBUG] = "Debug",
+        [EXCEPT_IA32_NMI] = "Non-Maskable Interrupt (NMI)",
+        [EXCEPT_IA32_BREAKPOINT] = "Breakpoint",
+        [EXCEPT_IA32_OVERFLOW] = "Overflow",
+        [EXCEPT_IA32_BOUND] = "Bound Range Exceeded",
+        [EXCEPT_IA32_INVALID_OPCODE] = "Invalid opcode",
+        [EXCEPT_IA32_DOUBLE_FAULT] = "Double Fault",
+        [EXCEPT_IA32_INVALID_TSS] = "Invalid TSS",
+        [EXCEPT_IA32_SEG_NOT_PRESENT] = "Segment not presented",
+        [EXCEPT_IA32_STACK_FAULT] = "Stack segment Fault",
+        [EXCEPT_IA32_GP_FAULT] = "General Protection Fault",
+        [EXCEPT_IA32_PAGE_FAULT] = "Page Fault",
+        [EXCEPT_IA32_FP_ERROR] = "x87 Floating Point Exception",
+        [EXCEPT_IA32_ALIGNMENT_CHECK] = "Alignment Check",
+        [EXCEPT_IA32_MACHINE_CHECK] = "Machine Check",
+        [EXCEPT_IA32_SIMD] = "SIMD Floating Point Exception",
+};
+
+static char* TABLE_NAME[] = {
+        "GDT",
+        "IDT",
+        "LDT",
+        "IDT"
+};
+
+static void register_handler(void* handler, int vector, int override);
+static struct idt_entry_t idt[256];
+static struct idt_entry_t* default_idt = 0;
+
+extern void div0_handler();
+extern void debug_handler();
+extern void breakpoint_handler();
+extern void overflow_handler();
+extern void bound_range_handler();
+extern void invalid_opcode_handler();
+extern void device_not_avail_handler();
+extern void double_fault_handler();
+extern void invalid_tss_handler();
+extern void segment_not_present_handler();
+extern void stack_segment_fault_handler();
+extern void gpf_handler();
+extern void pf_handler();
+extern void x87_fp_exception_handler();
+extern void alignment_check_handler();
+extern void simd_fp_exception_handler();
+
+//Override all idt entries with our own handler.
+void hook_idt() {
+    if(!default_idt) {
+        struct idt_ptr_t old_idt_ptr = {0};
+        __asm__ volatile (
+            "sidt %0"
+            :
+            : "m" (old_idt_ptr)
+        );
+
+        default_idt = (struct idt_entry_t*)old_idt_ptr.address;
+        //Copy all of the old interrupt handlers.
+        for(int i = 0; i < 256; i++) {
+            idt[i] = default_idt[i];
+        }
+    }
+  
+   /*
+    * The bios might set some handlers by itself, but we are going to cross our fingers that
+    * these are not too important and try to remove theirs and install ours, but we are not
+    * gonna assert just so we won't cause any problem with booting since this is just a debugging
+    * feature anyways
+    *
+    * we are not going to try and unregister the NMI and Machine Check exceptions because these
+    * are stuff that might be actually needed by the bios to act correctly.
+    *
+    * just cross fingers they don't use page faults or something alike :shrug:
+    */
+    register_handler(div0_handler, 0x0, 1);
+    register_handler(debug_handler, 0x1, 1);
+    register_handler(breakpoint_handler, 0x3, 1);
+    register_handler(overflow_handler, 0x4, 1);
+    register_handler(bound_range_handler, 0x5, 1);
+    register_handler(invalid_opcode_handler, 0x6, 1);
+    register_handler(device_not_avail_handler, 0x7, 1);
+    register_handler(double_fault_handler, 0x8, 1);
+    register_handler(invalid_tss_handler, 0xA, 1);
+    register_handler(segment_not_present_handler, 0xB, 1);
+    register_handler(stack_segment_fault_handler, 0xC, 1);
+    register_handler(gpf_handler, 0xD,1);
+    register_handler(pf_handler, 0xE, 1);
+    register_handler(x87_fp_exception_handler, 0x10, 1);
+    register_handler(alignment_check_handler, 0x11, 1);
+    register_handler(simd_fp_exception_handler, 0x13, 1);
+
+    struct idt_ptr_t idt_ptr = {
+        sizeof(idt) - 1,
+        (UINT64)idt
+    };
+
+    __asm__ volatile (
+        "lidt %0"
+        :
+        : "m" (idt_ptr)
+    );
+}
+
+void unhook_idt() {
+    //Copy all of the old interrupt handlers.
+    for(int i = 0; i < 256; i++) {
+        idt[i] = default_idt[i];
+    }
+}  
+ 
+
+static void register_handler(void* handler, int vector, int override) {
+    //Check if the entry is already present.
+    if(!override) {
+        if(idt[vector].type_attr & (1 << 7)) {
+            return;
+        }
+    }
+
+    UINT16 cs = 0;
+
+    __asm__ volatile (
+        "mov %%cs, %0"
+        :
+        : "m" (cs)
+    );
+
+    idt[vector].offset_low = (UINT16)handler;
+    idt[vector].selector = cs;
+    idt[vector].ist = 0;
+    //Present, DPL 0, Storage Segment 0, trap gate.
+    idt[vector].type_attr = 0x8e;
+    idt[vector].offset_mid = (UINT16)((size_t)handler >> 16);
+    idt[vector].offset_high = (UINT32)((size_t)handler >> 32);
+    idt[vector].zero = 0;
+}
+void interrupt_handler(const unsigned int InterruptType, const struct regs_t* ctx) {
+    // print the exception itself
+    if(InterruptType < ARRAY_SIZE(EXCEPTION_NAMES) && EXCEPTION_NAMES[InterruptType] != 0) {
+        DebugPrint(0, "Exception: %a\n", EXCEPTION_NAMES[InterruptType]);
+    }else {
+        DebugPrint(0, "Exception: %d\n", InterruptType);
+    }
+    DebugPrint(0, "function addr: %p\n", interrupt_handler);
+
+    // print the exception data if needed
+    switch(InterruptType) {
+        // has a selector
+        case EXCEPT_IA32_INVALID_TSS:
+        case EXCEPT_IA32_SEG_NOT_PRESENT:
+        case EXCEPT_IA32_STACK_FAULT:
+        case EXCEPT_IA32_GP_FAULT: {
+            if(ctx->ExceptionData != 0) {
+                const char* processor = ctx->ExceptionData & BIT0 ? "External" : "Internal";
+                const char* table = TABLE_NAME[(ctx->ExceptionData >> 1u) & 0b11];
+                int index = ctx->ExceptionData & 0xFFF8;
+                DebugPrint(0, "Selector(processor=%a, table=%a, index=%x)\n", processor, table, index);
+            }
+        } break;
+
+        // has a reason
+        case EXCEPT_IA32_PAGE_FAULT: {
+            DebugPrint(0, "Reason: %a\n", ctx->ExceptionData & BIT0 ? "Page-Protection violation" : "Non-Present page");
+            DebugPrint(0, "Mode: %a\n", ctx->ExceptionData & BIT2 ? "User" : "Supervisor");
+            if(ctx->ExceptionData & BIT4) {
+                DebugPrint(0, "Operation: Instruction Fetch\n");
+            }else if(ctx->ExceptionData & BIT3) {
+                DebugPrint(0, "Operation: Reserved Write\n");
+            }else {
+                DebugPrint(0, "Operation: %a\n", ctx->ExceptionData & BIT1 ? "Write" : "Read");
+            }
+        } break;
+
+        // no exception data
+        default:
+            if(ctx->ExceptionData != 0) {
+                DebugPrint(0, "Exception data: %d\n", ctx->ExceptionData);
+            }
+            break;
+    }
+
+    // prepare some bits
+    IA32_EFLAGS32 flags = { .UintN = ctx->Rflags };
+    char _cf = (char) ((flags.Bits.CF) != 0 ? 'C' : '-');
+    char _pf = (char) ((flags.Bits.PF) != 0 ? 'P' : '-');
+    char _af = (char) ((flags.Bits.AF) != 0 ? 'A' : '-');
+    char _zf = (char) ((flags.Bits.ZF) != 0 ? 'Z' : '-');
+    char _sf = (char) ((flags.Bits.SF) != 0 ? 'S' : '-');
+    char _tf = (char) ((flags.Bits.TF) != 0 ? 'T' : '-');
+    char _if = (char) ((flags.Bits.IF) != 0 ? 'I' : '-');
+    int cpl = flags.Bits.IOPL;
+
+    // print out the full state
+    DebugPrint(0, "RAX=%016llx RBX=%016llx\nRCX=%016llx RDX=%016llx\n", ctx->Rax, ctx->Rbx, ctx->Rcx, ctx->Rdx);
+    DebugPrint(0, "RSI=%016llx RDI=%016llx\nRBP=%016llx RSP=%016llx\n", ctx->Rsi, ctx->Rdi, ctx->Rbp, ctx->Rsp);
+    DebugPrint(0, "R8 =%016llx R9 =%016llx\nR10=%016llx R11=%016llx\n", ctx->R8, ctx->R9, ctx->R10, ctx->R10);
+    DebugPrint(0, "R12=%016llx R13=%016llx\nR14=%016llx R15=%016llx\n", ctx->R12, ctx->R13, ctx->R14, ctx->R15);
+    DebugPrint(0, "RIP=%016llx RFL=%08lx [%c%c%c%c%c%c%c] CPL=%d\n", ctx->Rip, (UINT32)ctx->Rflags, _if, _tf, _sf, _zf, _af, _pf, _cf, cpl);
+    DebugPrint(0, "ES =%04x DPL=%d       ", ctx->Es & 0xFFF8, ctx->Es & 0b11);
+    DebugPrint(0, "CS =%04x DPL=%d\n", ctx->Cs & 0xFFF8, ctx->Cs & 0b11);
+    DebugPrint(0, "SS =%04x DPL=%d       ", ctx->Ss & 0xFFF8, ctx->Ss & 0b11);
+    DebugPrint(0, "DS =%04x DPL=%d\n", ctx->Ds & 0xFFF8, ctx->Ds & 0b11);
+    DebugPrint(0, "FS =%04x DPL=%d       ", ctx->Fs & 0xFFF8, ctx->Fs & 0b11);
+    DebugPrint(0, "GS =%04x DPL=%d\n", ctx->Gs & 0xFFF8, ctx->Gs & 0b11);
+    DebugPrint(0, "LDT=%04x DPL=%d       ", ctx->Ldtr & 0xFFF8, ctx->Ldtr & 0b11);
+    DebugPrint(0, "TR =%04x DPL=%d\n", ctx->Tr & 0xFFF8, ctx->Tr & 0b11);
+    DebugPrint(0, "GDT=%016llx %08llx\n", ctx->Gdtr[0], ctx->Gdtr[1]);
+    DebugPrint(0, "IDT=%016llx %08llx\n", ctx->Idtr[0], ctx->Idtr[1]);
+    DebugPrint(0, "CR0=%08x CR2=%016llx\nCR3=%016llx CR4=%08x\n", ctx->Cr0, ctx->Cr2, ctx->Cr3, ctx->Cr4);
+
+    // TODO: debug registers
+    // TODO: fpu registers
+
+    DebugPrint(0, ":(");
+
+    // and die
+    CpuDeadLoop();
+}
+

--- a/src/debug/exception.h
+++ b/src/debug/exception.h
@@ -1,0 +1,60 @@
+#ifndef TOMATBOOT_UEFI_DEBUG_EXCEPTION_H
+#define TOMATBOOT_UEFI_DEBUG_EXCEPTION_H
+#include <Uefi.h>
+
+struct idt_ptr_t {
+    UINT16 size;
+    /* Start address */
+    UINT64 address;
+} __attribute((packed));
+
+struct idt_entry_t {
+    UINT16 offset_low;
+    UINT16 selector;
+    UINT8 ist;
+    UINT8 type_attr;
+    UINT16 offset_mid;
+    UINT32 offset_high;
+    UINT32 zero;
+} __attribute((packed));
+
+struct regs_t {
+    UINT64 Cr0;
+    UINT64 Cr2;
+    UINT64 Cr3;
+    UINT64 Cr4;
+    UINT64 Ldtr;
+    UINT64 Tr;
+    UINT64 Gdtr[2];
+    UINT64 Idtr[2];
+    UINT64 Gs;
+    UINT64 Fs;
+    UINT64 Es;
+    UINT64 Ds;
+    UINT64 R15;
+    UINT64 R14;
+    UINT64 R13;
+    UINT64 R12;
+    UINT64 R11;
+    UINT64 R10;
+    UINT64 R9;
+    UINT64 R8;
+    UINT64 Rbp;
+    UINT64 Rdi;
+    UINT64 Rsi;
+    UINT64 Rdx;
+    UINT64 Rcx;
+    UINT64 Rbx;
+    UINT64 Rax;
+    UINT64 ExceptionData;
+    UINT64 Rip;
+    UINT64 Cs;
+    UINT64 Rflags;
+    UINT64 Rsp;
+    UINT64 Ss;
+};
+
+void hook_idt();
+void unhook_idt();
+#endif
+

--- a/src/debug/exception.nasm
+++ b/src/debug/exception.nasm
@@ -1,0 +1,131 @@
+global div0_handler
+global debug_handler
+global breakpoint_handler
+global overflow_handler
+global bound_range_handler
+global invalid_opcode_handler
+global device_not_avail_handler
+global double_fault_handler
+global invalid_tss_handler
+global segment_not_present_handler
+global stack_segment_fault_handler
+global gpf_handler
+global pf_handler
+global x87_fp_exception_handler
+global alignment_check_handler
+global simd_fp_exception_handler
+section .text
+
+%macro common_handler 1
+cld
+push rax
+push rbx
+push rcx
+push rdx
+push rsi
+push rdi
+push rbp
+push r8
+push r9
+push r10
+push r11
+push r12
+push r13
+push r14
+push r15
+mov  rax, ds
+push rax
+mov  rax, es
+push rax
+mov  rax, fs
+push rax
+mov  rax, gs
+push rax
+; Push GDT register and IDT register
+xor  rax, rax
+push rax
+push rax
+sidt [rsp]
+
+mov     bx, word [rsp]
+mov     rax, qword [rsp + 2]
+mov     qword [rsp], rax
+mov     word [rsp + 8], bx
+
+xor rax, rax
+push rax
+push rax
+sgdt [rsp]
+mov     bx, word [rsp]
+mov     rax, qword [rsp + 2]
+mov     qword [rsp], rax
+mov     word [rsp + 8], bx
+xor rax, rax
+
+; Tr and Ldtr
+str  ax
+push rax
+sldt ax
+push rax
+; Control registers
+mov  rax, cr4
+push rax
+mov  rax, cr3
+push rax
+mov  rax, cr2
+push rax
+xor  rax, rax
+mov  rax, cr0
+push rax
+
+mov rcx, %1
+mov rdx, rsp
+; Shadow space on the stack
+; required by the Microsoft x64 calling convention.
+sub rsp, 4 * 8 + 8
+extern interrupt_handler
+call interrupt_handler
+hlt
+%endmacro
+
+%macro exception_handler 1
+push 0
+common_handler %1
+%endmacro
+
+%macro exception_handler_error 1
+common_handler %1
+%endmacro
+
+div0_handler:
+    exception_handler 0x0
+debug_handler:
+    exception_handler 0x1
+breakpoint_handler:
+    exception_handler 0x3
+overflow_handler:
+    exception_handler 0x4
+bound_range_handler:
+    exception_handler 0x5
+invalid_opcode_handler:
+    exception_handler 0x6
+device_not_avail_handler:
+    exception_handler 0x7
+double_fault_handler:
+    exception_handler_error 0x8
+invalid_tss_handler:
+    exception_handler_error 0xA
+segment_not_present_handler:
+    exception_handler_error 0xB
+stack_segment_fault_handler:
+    exception_handler_error 0xC
+gpf_handler:
+    exception_handler_error 0xD
+pf_handler:
+    exception_handler_error 0xE
+x87_fp_exception_handler:
+    exception_handler 0x10
+alignment_check_handler:
+    exception_handler_error 0x11
+simd_fp_exception_handler:
+    exception_handler 0x13

--- a/src/main.c
+++ b/src/main.c
@@ -6,173 +6,12 @@
 #include <menus/menus.h>
 #include <elf64/elf64.h>
 #include "config.h"
+#include <debug/exception.h>
 
 EFI_HANDLE gImageHandle;
 EFI_SYSTEM_TABLE* gST;
 EFI_RUNTIME_SERVICES* gRT;
 EFI_BOOT_SERVICES* gBS;
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Exception handlers
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-static int EXCEPTIONS[] = {
-        EXCEPT_IA32_DIVIDE_ERROR,
-        EXCEPT_IA32_DEBUG,
-        EXCEPT_IA32_NMI,
-        EXCEPT_IA32_BREAKPOINT,
-        EXCEPT_IA32_OVERFLOW,
-        EXCEPT_IA32_BOUND,
-        EXCEPT_IA32_INVALID_OPCODE,
-        EXCEPT_IA32_DOUBLE_FAULT,
-        EXCEPT_IA32_INVALID_TSS,
-        EXCEPT_IA32_SEG_NOT_PRESENT,
-        EXCEPT_IA32_STACK_FAULT,
-        EXCEPT_IA32_GP_FAULT,
-        EXCEPT_IA32_PAGE_FAULT,
-        EXCEPT_IA32_FP_ERROR,
-        EXCEPT_IA32_ALIGNMENT_CHECK,
-        EXCEPT_IA32_MACHINE_CHECK,
-        EXCEPT_IA32_SIMD,
-};
-
-static const char* EXCEPTION_NAMES[] = {
-        [EXCEPT_IA32_DIVIDE_ERROR] = "Divide by zero",
-        [EXCEPT_IA32_DEBUG] = "Debug",
-        [EXCEPT_IA32_NMI] = "Non-Maskable Interrupt (NMI)",
-        [EXCEPT_IA32_BREAKPOINT] = "Breakpoint",
-        [EXCEPT_IA32_OVERFLOW] = "Overflow",
-        [EXCEPT_IA32_BOUND] = "Bound Range Exceeded",
-        [EXCEPT_IA32_INVALID_OPCODE] = "Invalid opcode",
-        [EXCEPT_IA32_DOUBLE_FAULT] = "Double Fault",
-        [EXCEPT_IA32_INVALID_TSS] = "Invalid TSS",
-        [EXCEPT_IA32_SEG_NOT_PRESENT] = "Segment not presented",
-        [EXCEPT_IA32_STACK_FAULT] = "Stack segment Fault",
-        [EXCEPT_IA32_GP_FAULT] = "General Protection Fault",
-        [EXCEPT_IA32_PAGE_FAULT] = "Page Fault",
-        [EXCEPT_IA32_FP_ERROR] = "x87 Floating Point Exception",
-        [EXCEPT_IA32_ALIGNMENT_CHECK] = "Alignment Check",
-        [EXCEPT_IA32_MACHINE_CHECK] = "Machine Check",
-        [EXCEPT_IA32_SIMD] = "SIMD Floating Point Exception",
-};
-
-static char* TABLE_NAME[] = {
-        "GDT",
-        "IDT",
-        "LDT",
-        "IDT"
-};
-
-static void interrupt_handler(const EFI_EXCEPTION_TYPE InterruptType, const EFI_SYSTEM_CONTEXT SystemContext) {
-    EFI_SYSTEM_CONTEXT_X64* ctx = SystemContext.SystemContextX64;
-
-    // print the exception itself
-    if(InterruptType < ARRAY_SIZE(EXCEPTION_NAMES) && EXCEPTION_NAMES[InterruptType] != 0) {
-        DebugPrint(0, "Exception: %a\n", EXCEPTION_NAMES[InterruptType]);
-    }else {
-        DebugPrint(0, "Exception: %d\n", InterruptType);
-    }
-
-    // print the exception data if needed
-    switch(InterruptType) {
-        // has a selector
-        case EXCEPT_IA32_INVALID_TSS:
-        case EXCEPT_IA32_SEG_NOT_PRESENT:
-        case EXCEPT_IA32_STACK_FAULT:
-        case EXCEPT_IA32_GP_FAULT: {
-            if(ctx->ExceptionData != 0) {
-                const char* processor = ctx->ExceptionData & BIT0 ? "External" : "Internal";
-                const char* table = TABLE_NAME[(ctx->ExceptionData >> 1u) & 0b11];
-                int index = ctx->ExceptionData & 0xFFF8;
-                DebugPrint(0, "Selector(processor=%a, table=%a, index=%x)\n", processor, table, index);
-            }
-        } break;
-
-        // has a reason
-        case EXCEPT_IA32_PAGE_FAULT: {
-            DebugPrint(0, "Reason: %a\n", ctx->ExceptionData & BIT0 ? "Page-Protection violation" : "Non-Present page");
-            DebugPrint(0, "Mode: %a\n", ctx->ExceptionData & BIT2 ? "User" : "Supervisor");
-            DebugPrint(0, "Address: %p\n", AsmReadCr2());
-            if(ctx->ExceptionData & BIT4) {
-                DebugPrint(0, "Operation: Instruction Fetch\n");
-            }else if(ctx->ExceptionData & BIT3) {
-                DebugPrint(0, "Operation: Reserved Write\n");
-            }else {
-                DebugPrint(0, "Operation: %a\n", ctx->ExceptionData & BIT1 ? "Write" : "Read");
-            }
-        } break;
-
-        // no exception data
-        default:
-            if(ctx->ExceptionData != 0) {
-                DebugPrint(0, "Exception data: %d\n", ctx->ExceptionData);
-            }
-            break;
-    }
-
-    // prepare some bits
-    IA32_EFLAGS32 flags = { .UintN = ctx->Rflags };
-    char _cf = (char) ((flags.Bits.CF) != 0 ? 'C' : '-');
-    char _pf = (char) ((flags.Bits.PF) != 0 ? 'P' : '-');
-    char _af = (char) ((flags.Bits.AF) != 0 ? 'A' : '-');
-    char _zf = (char) ((flags.Bits.ZF) != 0 ? 'Z' : '-');
-    char _sf = (char) ((flags.Bits.SF) != 0 ? 'S' : '-');
-    char _tf = (char) ((flags.Bits.TF) != 0 ? 'T' : '-');
-    char _if = (char) ((flags.Bits.IF) != 0 ? 'I' : '-');
-    int cpl = flags.Bits.IOPL;
-
-    // print out the full state
-    DebugPrint(0, "RAX=%016llx RBX=%016llx\nRCX=%016llx RDX=%016llx\n", ctx->Rax, ctx->Rbx, ctx->Rcx, ctx->Rdx);
-    DebugPrint(0, "RSI=%016llx RDI=%016llx\nRBP=%016llx RSP=%016llx\n", ctx->Rsi, ctx->Rdi, ctx->Rbp, ctx->Rsp);
-    DebugPrint(0, "R8 =%016llx R9 =%016llx\nR10=%016llx R11=%016llx\n", ctx->R8, ctx->R9, ctx->R10, ctx->R10);
-    DebugPrint(0, "R12=%016llx R13=%016llx\nR14=%016llx R15=%016llx\n", ctx->R12, ctx->R13, ctx->R14, ctx->R15);
-    DebugPrint(0, "RIP=%016llx RFL=%08lx [%c%c%c%c%c%c%c] CPL=%d\n", ctx->Rip, (uint32_t)ctx->Rflags, _if, _tf, _sf, _zf, _af, _pf, _cf, cpl);
-    DebugPrint(0, "ES =%04x DPL=%d       ", ctx->Es & 0xFFF8, ctx->Es & 0b11);
-    DebugPrint(0, "CS =%04x DPL=%d\n", ctx->Cs & 0xFFF8, ctx->Cs & 0b11);
-    DebugPrint(0, "SS =%04x DPL=%d       ", ctx->Ss & 0xFFF8, ctx->Ss & 0b11);
-    DebugPrint(0, "DS =%04x DPL=%d\n", ctx->Ds & 0xFFF8, ctx->Ds & 0b11);
-    DebugPrint(0, "FS =%04x DPL=%d       ", ctx->Fs & 0xFFF8, ctx->Fs & 0b11);
-    DebugPrint(0, "GS =%04x DPL=%d\n", ctx->Gs & 0xFFF8, ctx->Gs & 0b11);
-    DebugPrint(0, "LDT=%04x DPL=%d       ", ctx->Ldtr & 0xFFF8, ctx->Ldtr & 0b11);
-    DebugPrint(0, "TR =%04x DPL=%d\n", ctx->Tr & 0xFFF8, ctx->Tr & 0b11);
-    DebugPrint(0, "GDT=%016llx %08llx\n", ctx->Gdtr[0], ctx->Gdtr[1]);
-    DebugPrint(0, "IDT=%016llx %08llx\n", ctx->Idtr[0], ctx->Idtr[1]);
-    DebugPrint(0, "CR0=%08x CR2=%016llx\nCR3=%016llx CR4=%08x\n", ctx->Cr0, ctx->Cr2, ctx->Cr3, ctx->Cr4);
-
-    // TODO: debug registers
-    // TODO: fpu registers
-
-    DebugPrint(0, ":(");
-
-    // and die
-    CpuDeadLoop();
-}
-
-static void setup_exception_handlers() {
-    EFI_CPU_ARCH_PROTOCOL* cpuArch = NULL;
-    if(EFI_ERROR(gBS->LocateProtocol(&gEfiCpuArchProtocolGuid, NULL, (void**)&cpuArch))) return;
-    if(!cpuArch) return;
-    DebugPrint(0, "Cpu arch found, setting exception handlers\n");
-
-    /*
-     * The bios might set some handlers by itself, but we are going to cross our fingers that
-     * these are not too important and try to remove theirs and install ours, but we are not
-     * gonna assert just so we won't cause any problem with booting since this is just a debugging
-     * feature anyways
-     *
-     * we are not going to try and unregister the NMI and Machine Check exceptions because these
-     * are stuff that might be actually needed by the bios to act correctly.
-     *
-     * just cross fingers they don't use page faults or something alike :shrug:
-     */
-    for(int i = 0; i < ARRAY_SIZE(EXCEPTIONS); i++) {
-        if(EXCEPTIONS[i] != EXCEPT_IA32_NMI && EXCEPTIONS[i] != EXCEPT_IA32_MACHINE_CHECK) {
-            cpuArch->RegisterInterruptHandler(cpuArch, EXCEPTIONS[i], NULL);
-        }
-
-        cpuArch->RegisterInterruptHandler(cpuArch, EXCEPTIONS[i], interrupt_handler);
-    }
-}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // The entry
@@ -189,7 +28,6 @@ EFI_STATUS EFIAPI EfiMain(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *System
 
     // setup all of the libraries
     DebugLibConstructor(ImageHandle, SystemTable);
-    setup_exception_handlers();
 
     // load the boot config
     get_boot_entries(&boot_entries);

--- a/src/menus/setup_menu.c
+++ b/src/menus/setup_menu.c
@@ -2,6 +2,7 @@
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Protocol/GraphicsOutput.h>
+#include <debug/exception.h>
 
 #include <config.h>
 #include <util/draw_utils.h>
@@ -102,7 +103,6 @@ menu_t enter_setup_menu() {
         });
         write_at(controls_start, control_line++, "Boot Delay: %d", config.boot_delay);
 
-
         /*
          * Graphics Mode: changes the resolution and format of the graphics buffer
          */
@@ -137,6 +137,19 @@ menu_t enter_setup_menu() {
         });
         boot_entry_t* entry = &boot_entries.entries[config.default_os];
         write_at(controls_start, control_line++, "Default OS: %a (%a)", entry->name, entry->path);
+
+        #ifdef TBOOT_DEBUG
+        IF_SELECTED({
+            // check last button press
+            if(op == OP_INC) {
+                hook_idt();
+            }else if(op == OP_DEC) {
+                unhook_idt();
+            }
+        });
+        write_at(controls_start, control_line++, "Hook IDT", config.boot_delay);
+        #endif
+
 
         ////////////////////////////////////////////////////////////////////////
         // Input handling


### PR DESCRIPTION
This is necessary since on some older UEFI implementations
the CPU architecture protocol is broken.